### PR TITLE
Update configure.sh

### DIFF
--- a/LookingGlass/configure.sh
+++ b/LookingGlass/configure.sh
@@ -219,7 +219,7 @@ function requirements()
   fi
 
   # Array of required functions
-  local REQUIRE=(host mtr iputils-ping traceroute sqlite3)
+  local REQUIRE=(host mtr iputils-ping traceroute sqlite3 php.-sqlite)
 
   # Loop through required & install
   for i in "${REQUIRE[@]}"; do


### PR DESCRIPTION
PHP throws an error unless php5-sqlite is installed:
(mod_fastcgi.c.2676) FastCGI-stderr: PHP Fatal error:  Uncaught exception 'PDOException' with message 'could not find driver' in /var/www/lg/LookingGlass/RateLimit.php:65
Raspbian 7 with lightttpd