### PR TITLE
Secure the LookingGlass directory

### DIFF
--- a/LookingGlass/.htaccess
+++ b/LookingGlass/.htaccess
@@ -1,0 +1,2 @@
+order deny,allow
+deny from all


### PR DESCRIPTION
When enabling rate limiting, the rate limiting database can be downloaded by anyone that knows the URL of the rate limit database. This modification will disallow access to that database as well as anything else in the LookingGlass directory. As far as I can tell, all files in this directory should not be accessed directly anyway.
