### PR TITLE
Fixed XSS issue

### DIFF
--- a/LookingGlass/LookingGlass.php
+++ b/LookingGlass/LookingGlass.php
@@ -252,7 +252,7 @@ class LookingGlass
                         && ($traceCount - 1) === $lastFail
                         &&  $fail >= $failCount
                     ) {
-                        echo str_pad($str . '<br />-- Traceroute timed out --<br />', 1024, ' ', STR_PAD_RIGHT);
+                        echo str_pad(htmlentities($str) . '<br />-- Traceroute timed out --<br />', 1024, ' ', STR_PAD_RIGHT);
                         break;
                     }
                     $lastFail = $traceCount;
@@ -261,7 +261,7 @@ class LookingGlass
             }
 
             // pad string for live output
-            echo str_pad($str . '<br />', 1024, ' ', STR_PAD_RIGHT);
+            echo str_pad(htmlentities($str) . '<br />', 1024, ' ', STR_PAD_RIGHT);
 
             // flush output buffering
             @ob_flush();


### PR DESCRIPTION
Response data from commands is not escaped before printing, leading to a potential XSS attack on all sites hosting the looking glass.

This can potentially even lead to viable attacks across subdomains via session fixation. (User is tricked into going to this url, either in a hidden iframe/etc. Cookies are overwritten with attacker controlled cookies, and user logs in while still using attacker controlled cookies)

A proof of concept can be viewed by going to the URL in the looking glass:
/ajax.php?cmd=host&host=87.204.122.210

The reverse DNS record for that domain contains html which inserts an image into the page.