### PR TITLE
Fix for PHP7.0

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -41,7 +41,7 @@ if (isset($_GET['cmd']) && isset($_GET['host'])) {
         $limit->rateLimit($rateLimit);
 
         // execute command
-        $output = $lg->$_GET['cmd']($_GET['host']);
+        $output = $lg->{$_GET['cmd']}($_GET['host']);
         if ($output) {
             exit();
         }


### PR DESCRIPTION
This adjustment fixed the "PHP Fatal error:  Uncaught Error: Function name must be a string in Ajax.php" for me running PHP7.0
